### PR TITLE
feat: support primitive schema types for path params

### DIFF
--- a/api.go
+++ b/api.go
@@ -62,6 +62,8 @@ type PathParam struct {
 	// Regexp is a regular expression used to validate the param.
 	// An empty string means that no validation is applied.
 	Regexp string
+	// Type of the param (string, number, integer, boolean)
+	Type string
 }
 
 // QueryParam is a paramater that's used in the querystring of a URL.

--- a/schema.go
+++ b/schema.go
@@ -49,7 +49,19 @@ func (api *API) createOpenAPI() (spec *openapi3.T, err error) {
 			// Add the route params.
 			for _, k := range getSortedKeys(route.Params.Path) {
 				v := route.Params.Path[k]
-				ps := openapi3.NewStringSchema()
+
+				var ps *openapi3.Schema
+				switch v.Type {
+				case "number":
+					ps = openapi3.NewFloat64Schema()
+				case "integer":
+					ps = openapi3.NewIntegerSchema()
+				case "boolean":
+					ps = openapi3.NewBoolSchema()
+				default:
+					ps = openapi3.NewStringSchema()
+				}
+
 				if v.Regexp != "" {
 					ps.WithPattern(v.Regexp)
 				}


### PR DESCRIPTION
Support primitive schema types for path parameters:

```go
api := rest.NewAPI("API")
api.Get("/user/{id}).HasPathParameter("id", rest.PathParam{Type: "integer"})
```

This provides the swagger ui (and auto-generated api clients) with additional type information for sending the correct type of path params to the server.