### PR TITLE
feat: support creation of query parameters with primitive schema types

### DIFF
--- a/api.go
+++ b/api.go
@@ -63,7 +63,7 @@ type PathParam struct {
 	// An empty string means that no validation is applied.
 	Regexp string
 	// Type of the param (string, number, integer, boolean)
-	Type string
+	Type Primitive
 }
 
 // QueryParam is a paramater that's used in the querystring of a URL.
@@ -74,7 +74,18 @@ type QueryParam struct {
 	Required bool
 	// AllowEmpty sets whether the querystring parameter can be empty.
 	AllowEmpty bool
+	// Type of the param (string, number, integer, boolean)
+	Type Primitive
 }
+
+type Primitive int
+
+const (
+	PrimitiveString Primitive = iota
+	PrimitiveBool
+	PrimitiveInteger
+	PrimitiveFloat64
+)
 
 // MethodToRoute maps from a HTTP method to a Route.
 type MethodToRoute map[Method]*Route
@@ -240,6 +251,12 @@ func (rm *Route) HasRequestModel(request Model) *Route {
 // HasPathParameter configures a path parameter for the route.
 func (rm *Route) HasPathParameter(name string, p PathParam) *Route {
 	rm.Params.Path[name] = p
+	return rm
+}
+
+// HasPathParameter configures a path parameter for the route.
+func (rm *Route) HasQueryParameter(name string, q QueryParam) *Route {
+	rm.Params.Query[name] = q
 	return rm
 }
 


### PR DESCRIPTION
Support creating query parameters through the 'rest' api with primitive OpenAPI schema types.

```go
api := rest.NewAPI("API")
api.Get("/user").HasQueryParameter("id", rest.QueryParam{Type: rest.PrimitiveInteger, Required: true })
```

The query params are registered in much the same way as the path params, with a couple of different settings (Required, AllowEmpty).

I split out the OpenAPI primitive schema types into an enum for better DX and safety.

Thanks for building this, it's a great project!