### PR TITLE
fixed issue where time.Time field comments are all set to the final time.Time field comment

### DIFF
--- a/api.go
+++ b/api.go
@@ -26,9 +26,9 @@ func NewAPI(name string, opts ...APIOpts) *API {
 	return api
 }
 
-var defaultKnownTypes = map[reflect.Type]*openapi3.Schema{
-	reflect.TypeOf(time.Time{}):  openapi3.NewDateTimeSchema(),
-	reflect.TypeOf(&time.Time{}): openapi3.NewDateTimeSchema().WithNullable(),
+var defaultKnownTypes = map[reflect.Type]openapi3.Schema{
+	reflect.TypeOf(time.Time{}):  *openapi3.NewDateTimeSchema(),
+	reflect.TypeOf(&time.Time{}): *openapi3.NewDateTimeSchema().WithNullable(),
 }
 
 // Route models a single API route.
@@ -129,7 +129,7 @@ type API struct {
 	// KnownTypes are added to the OpenAPI specification output.
 	// The default implementation:
 	//   Maps time.Time to a string.
-	KnownTypes map[reflect.Type]*openapi3.Schema
+	KnownTypes map[reflect.Type]openapi3.Schema
 
 	// comments from the package. This can be cleared once the spec has been created.
 	comments map[string]map[string]string

--- a/schema.go
+++ b/schema.go
@@ -260,13 +260,13 @@ func (api *API) RegisterModel(model Model, opts ...ModelOpts) (name string, sche
 	}
 
 	// It's known, but not in the schemaset yet.
-	if schema, ok = api.KnownTypes[t]; ok {
+	if knownSchema, ok := api.KnownTypes[t]; ok {
 		// Objects, enums, need to be references, so add it into the
 		// list.
-		if shouldBeReferenced(schema) {
-			api.models[name] = schema
+		if shouldBeReferenced(&knownSchema) {
+			api.models[name] = &knownSchema
 		}
-		return name, schema, nil
+		return name, &knownSchema, nil
 	}
 
 	var elementName string

--- a/schema_test.go
+++ b/schema_test.go
@@ -148,6 +148,13 @@ type WithMaps struct {
 	Amounts map[string]Pence `json:"amounts"`
 }
 
+type MultipleDateFieldsWithComments struct {
+	// DateField is a field containing a date
+	DateField time.Time `json:"dateField"`
+	// DateFieldA is another field containing a date
+	DateFieldA time.Time `json:"dateFieldA"`
+}
+
 func TestSchema(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -309,6 +316,14 @@ func TestSchema(t *testing.T) {
 						Regexp:      `field|otherField`,
 					}).
 					HasResponseModel(http.StatusOK, ModelOf[User]())
+				return
+			},
+		},
+		{
+			name: "multiple-dates-with-comments.yaml",
+			setup: func(api *API) (err error) {
+				api.Get("/dates").
+					HasResponseModel(http.StatusOK, ModelOf[MultipleDateFieldsWithComments]())
 				return
 			},
 		},

--- a/tests/multiple-dates-with-comments.yaml
+++ b/tests/multiple-dates-with-comments.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.0
+components:
+  schemas:
+    MultipleDateFieldsWithComments:
+      properties:
+        dateField:
+          description: DateField is a field containing a date
+          format: date-time
+          type: string
+        dateFieldA:
+          description: DateFieldA is another field containing a date
+          format: date-time
+          type: string
+      required:
+        - dateField
+        - dateFieldA
+      type: object
+info:
+  title: multiple-dates-with-comments.yaml
+  version: 0.0.0
+paths:
+  /dates:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MultipleDateFieldsWithComments'
+          description: ""
+        default:
+          description: ""


### PR DESCRIPTION
We were seeing the same comment against all time.Time fields, due to returning a pointer rather than value for `knownTypes`.  I've run all the tests and also checked it against our project using workspaces and it doesn't appear to have had any unintended side effects!