### PR TITLE
Ignore "go command required" error

### DIFF
--- a/getcomments/parser/parser.go
+++ b/getcomments/parser/parser.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/types"
@@ -9,6 +10,8 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
+var ErrGoCommandRequired = errors.New("go command required, not found")
+
 func Get(packageName string) (m map[string]string, err error) {
 	config := &packages.Config{
 		Mode:  packages.NeedTypes | packages.NeedTypesInfo | packages.NeedSyntax,
@@ -16,6 +19,9 @@ func Get(packageName string) (m map[string]string, err error) {
 	}
 	pkgs, err := packages.Load(config, packageName)
 	if err != nil {
+		if strings.HasPrefix(err.Error(), "err: go command required, not found: ") {
+			err = ErrGoCommandRequired
+		}
 		err = fmt.Errorf("error loading package %s: %w", packageName, err)
 		return
 	}

--- a/getcomments/parser/parser_test.go
+++ b/getcomments/parser/parser_test.go
@@ -2,7 +2,10 @@ package parser_test
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/a-h/rest/getcomments/parser"
 	"github.com/a-h/rest/getcomments/parser/tests/anonymous"
@@ -14,7 +17,6 @@ import (
 	"github.com/a-h/rest/getcomments/parser/tests/pointers"
 	"github.com/a-h/rest/getcomments/parser/tests/privatetypes"
 	"github.com/a-h/rest/getcomments/parser/tests/publictypes"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestGet(t *testing.T) {
@@ -88,5 +90,13 @@ func TestGet(t *testing.T) {
 				t.Error(diff)
 			}
 		})
+	}
+}
+
+func TestGet_WithoutToolchain(t *testing.T) {
+	t.Setenv("PATH", "")
+	_, err := parser.Get("github.com/a-h/rest/getcomments/parser/tests/docs")
+	if !errors.Is(err, parser.ErrGoCommandRequired) {
+		t.Fatalf("expected ErrGoCommandRequired, got %v", err)
 	}
 }

--- a/schema.go
+++ b/schema.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -394,6 +395,9 @@ func (api *API) getCommentsForPackage(pkg string) (pkgComments map[string]string
 		return pkgComments, nil
 	}
 	pkgComments, err = parser.Get(pkg)
+	if errors.Is(err, parser.ErrGoCommandRequired) {
+		err = nil
+	}
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
The comment parser fails with an "go command required" error when used in an environment that does not have a Go toolchain installed. Ignore this error so that the other functionality of the package can still be used.