### PR TITLE
fix: generic star type should be allowed

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -434,7 +434,8 @@ func shouldBeReferenced(schema *openapi3.Schema) bool {
 var normalizer = strings.NewReplacer("/", "_",
 	".", "_",
 	"[", "_",
-	"]", "_")
+	"]", "_",
+	"*", "_")
 
 func (api *API) normalizeTypeName(pkgPath, name string) string {
 	var omitPackage bool


### PR DESCRIPTION
I was trying on Generics and caught the error that Gernerics seem to have been left out of the key normalization stage of the process 