### PR TITLE
Refactor normalization handling and add ApplyPostNormalizeTransform

### DIFF
--- a/api.go
+++ b/api.go
@@ -151,6 +151,8 @@ type API struct {
 	// Apply customisation to a specific type by checking the t parameter.
 	// Apply customisations to all types by ignoring the t parameter.
 	ApplyCustomSchemaToType func(t reflect.Type, s *openapi3.Schema)
+
+	ApplyPostNormalizeTransform func(normalized string) string
 }
 
 // Merge route data into the existing configuration.

--- a/schema.go
+++ b/schema.go
@@ -444,8 +444,18 @@ func (api *API) normalizeTypeName(pkgPath, name string) string {
 			break
 		}
 	}
+
+	var normalized string
+
 	if omitPackage || pkgPath == "" {
-		return normalizer.Replace(name)
+		normalized = normalizer.Replace(name)
+	} else {
+		normalized = normalizer.Replace(pkgPath + "/" + name)
 	}
-	return normalizer.Replace(pkgPath + "/" + name)
+
+	if api.ApplyPostNormalizeTransform != nil {
+		normalized = api.ApplyPostNormalizeTransform(normalized)
+	}
+
+	return normalized
 }


### PR DESCRIPTION
## Problem / Use case

I have 3 types of the same struct name as a response model, it became a problem quickly, cause they were overriding each other (in order, i think).

```go
// one/type.go
type Response struct { x string }
```


```go
// two/type.go
type Response struct { y string }
```


```go
// three/type.go
type Response struct { z string }
```

With the current implement, you get just 1 Response and the rest is just gone.

## Proposed Solution

```go
func last[T any](slice []T, n int) []T {
	if n <= 0 {
		return nil
	}
	if len(slice) < n {
		return slice
	}
	return slice[len(slice)-n:]
}

opts = append(opts, func(a *rest.API) {
	a.ApplyPostNormalizeTransform = func(normalized string) string {
		normalized = strings.Join(last(strings.Split(normalized, "_"), 2), "_")
		return lo.PascalCase(normalized)
	}
})
api = rest.NewAPI(name, opts...)
```

now, i'll have `OneReponse`, `TwoResponse` and `ThreeResponse`

## Implementation Details
This pull request introduces a new hook to allow post-processing of normalized type names in the API schema generation logic. The main change is the addition of a configurable function that can be used to further transform normalized names after the default normalization logic has been applied.

Enhancements to type name normalization:

* Added an `ApplyPostNormalizeTransform` function field to the `API` struct in `api.go`, allowing custom post-processing of normalized type names.
* Updated the `normalizeTypeName` method in `schema.go` to call `ApplyPostNormalizeTransform` if it is set, enabling additional transformation of the normalized string before returning it.
